### PR TITLE
Add Thunderbird for Android to productivity.md

### DIFF
--- a/categories/productivity.md
+++ b/categories/productivity.md
@@ -62,7 +62,7 @@ App Name                   | Describe                  | Major Language         
 ### K  
 App Name                   | Describe                  | Major Language             | Download 
 :------------------------: | :------------------------ | :------------------------: | :------------------------: 
-[K-9 Mail](https://github.com/k9mail/k-9) | Advanced Email for Android | Java | [![Get it on Google Play](https://i.imgur.com/T9HnFlW.png)](https://play.google.com/store/apps/details?id=com.fsck.k9)
+ | | | 
 
 ### L  
 App Name                   | Describe                  | Major Language             | Download 
@@ -121,6 +121,7 @@ App Name                   | Describe                  | Major Language         
 :------------------------: | :------------------------ | :------------------------: | :------------------------: 
 [Tasks](https://github.com/dmfs/opentasks) | A task app for Android | Java | [![Get it on Google Play](https://i.imgur.com/T9HnFlW.png)](https://play.google.com/store/apps/details?id=org.dmfs.tasks)  
 [Text Fairy](https://github.com/renard314/textfairy) | Android OCR App | Java | [![Get it on Google Play](https://i.imgur.com/T9HnFlW.png)](https://play.google.com/store/apps/details?id=com.renard.ocr)  
+[Thunderbird for Android](https://github.com/thunderbird/thunderbird-android) | Official mobile version of the well-known E-Mail-app Thunderbird from Mozilla. (The mobile app is fka K-9 Mail) | Kotlin | [![Get it on Google Play](https://i.imgur.com/T9HnFlW.png)](https://play.google.com/store/apps/details?id=net.thunderbird.android)   [<img src="https://f-droid.org/badge/get-it-on.png" alt="available on F-Droid app store" height="120">](https://f-droid.org/packages/net.thunderbird.android/)
 [ToGoZip](https://github.com/k3b/ToGoZip/) | "Add To Zip" for android's share/send menu. | Java | [<img src="https://f-droid.org/badge/get-it-on.png" alt="available on F-Droid app store" height="45">](https://f-droid.org/app/de.k3b.android.toGoZip)
 [tudounotepad](https://github.com/geminiwen/tudounotepad) | A simple Notepad Application developed on Kotlin | Kotlin |  
 [Turbo Editor](https://github.com/vmihalachi/turbo-editor) | Simple, Powerful and Open Source Text Editor for Android | Java | [![Get it on Google Play](https://i.imgur.com/T9HnFlW.png)](https://play.google.com/store/apps/details?id=com.maskyn.fileeditor)


### PR DESCRIPTION
Replaced K-9 Mail with Mozilla's (so far) new Thunderbird for Android

 (Next to that: The K-9 Mail Repository on Github is now the Thunderbird for Android Repository)