### PR TITLE
feat: add Nextcloud, OpenTracks, and trale to business and health cat…

### DIFF
--- a/categories/business.md
+++ b/categories/business.md
@@ -7,6 +7,7 @@ A curated list of open-source applications for e-commerce, ERP, CRM, and other b
 | App Name | Description | Language | License | ⭐ Stars | Download |
 | :--- | :--- | :---: | :---: | :---: | :---: |
 | [**OpenPetra**](https://github.com/openpetra/openpetra) | Administration software (CRM/ERP) for charitable organizations. | `C#` | `GPL-3.0` | 120 | — |
+| [**Nextcloud**](https://github.com/nextcloud/android) | The official Android client for Nextcloud — access, share and sync files, calendars and contacts on your own server. | `Kotlin` | `GPL-2.0` | 5.3k | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=com.nextcloud.client) |
 | [**OpenShop.io**](https://github.com/openshopio/openshop.io-android) | A mobile E-commerce solution connected to Facebook Ads and Google. (Archived) | `Java` | `MIT` | 504 | — |
 
 ---

--- a/categories/health_fitness.md
+++ b/categories/health_fitness.md
@@ -11,9 +11,11 @@ A curated list of open-source health, wellness, and fitness apps for Android. Th
 | [**Android heart rate monitor**](https://github.com/phishman3579/android-heart-rate-monitor) | Uses the phone's camera and flash to determine heart rate. | `Java` | `Apache-2.0` | 474 | — |
 | [**fitPlant**](https://github.com/KrisKodira/fitPlant) | A fitness app where you grow virtual plants by tracking your exercise. | `Dart` | `MIT` | 32 | — |
 | [**Ishihara**](https://github.com/landtanin/Ishihara) | An application for testing color blindness using Ishihara plates. | `Java` | `MIT` | 3 | — |
+| [**OpenTracks**](https://github.com/OpenTracksApp/OpenTracks) | A privacy-focused sport tracking app that records GPS-based workouts without any data leaving your device. | `Java` | `Apache-2.0` | 1.2k | [![F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/en/packages/de.dennisguse.opentracks/) |
 | [**NightSight**](https://github.com/meghalagrawal/NightSight) | An app to decrease screen brightness below the system's minimum level. | `Java` | `Apache-2.0` | 24 | — |
 | [**Pedometer**](https://github.com/j4velin/Pedometer) | A lightweight pedometer app that uses the hardware step-sensor. | `Java` | `Apache-2.0` | 1.4k | — |
 | [**RunnerUp**](https://github.com/jonasoreland/runnerup) | An open-source run tracker for tracking fitness activities. | `Java` | `GPL-3.0` | 914 | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=org.runnerup) |
+| [**trale**](https://github.com/QuantumPhysique/trale) | A simple and privacy-respecting body weight diary app built with Flutter. | `Dart` | `MIT` | 135 | [![F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/en/packages/de.quantumrange.trale/) |
 
 ---
 


### PR DESCRIPTION
Added 3 popular missing open-source Android apps:

- **Nextcloud** (5.3k ⭐) to Business — widely used self-hosted file sync client
- **OpenTracks** (1.2k ⭐) to Health & Fitness — privacy-focused sport tracker
- **trale** (135 ⭐) to Health & Fitness — body weight diary app

All verified on GitHub with correct license and language info.