### PR TITLE
Add OpenHearing to Health & Fitness

### DIFF
--- a/categories/health_fitness.md
+++ b/categories/health_fitness.md
@@ -11,6 +11,7 @@ A curated list of open-source health, wellness, and fitness apps for Android. Th
 | [**Android heart rate monitor**](https://github.com/phishman3579/android-heart-rate-monitor) | Uses the phone's camera and flash to determine heart rate. | `Java` | `Apache-2.0` | 474 | — |
 | [**fitPlant**](https://github.com/KrisKodira/fitPlant) | A fitness app where you grow virtual plants by tracking your exercise. | `Dart` | `MIT` | 32 | — |
 | [**Ishihara**](https://github.com/landtanin/Ishihara) | An application for testing color blindness using Ishihara plates. | `Java` | `MIT` | 3 | — |
+| [**OpenHearing**](https://github.com/HMAKT99/OpenHearing) | Checks your hearing, builds a personal per-ear sound profile, and amplifies quiet sound in real time on any earbuds. | `Kotlin` | `GPL-3.0` | 7 | — |
 | [**OpenTracks**](https://github.com/OpenTracksApp/OpenTracks) | A privacy-focused sport tracking app that records GPS-based workouts without any data leaving your device. | `Java` | `Apache-2.0` | 1.4k | [![F-Droid](https://f-droid.org/badge/get-it-on.png)](https://f-droid.org/en/packages/de.dennisguse.opentracks) |
 | [**NightSight**](https://github.com/meghalagrawal/NightSight) | An app to decrease screen brightness below the system's minimum level. | `Java` | `Apache-2.0` | 24 | — |
 | [**Pedometer**](https://github.com/j4velin/Pedometer) | A lightweight pedometer app that uses the hardware step-sensor. | `Java` | `Apache-2.0` | 1.4k | — |


### PR DESCRIPTION
Adds [OpenHearing](https://github.com/HMAKT99/OpenHearing) to Health & Fitness, alphabetically between Ishihara and OpenTracks.

OpenHearing is a free, GPL-3.0 hearing-assistance app: it runs a pure-tone hearing check, builds a personal per-ear amplification profile from the result, and amplifies quiet sound in real time on any headset or earbuds. Kotlin / Jetpack Compose, no INTERNET permission, hard output-loudness limiter. It complements Ishihara (vision test) as the category's hearing entry.