### PR TITLE
Add SoulSync to Health & Fitness

### DIFF
--- a/categories/health_fitness.md
+++ b/categories/health_fitness.md
@@ -16,6 +16,7 @@ A curated list of open-source health, wellness, and fitness apps for Android. Th
 | [**NightSight**](https://github.com/meghalagrawal/NightSight) | An app to decrease screen brightness below the system's minimum level. | `Java` | `Apache-2.0` | 24 | — |
 | [**Pedometer**](https://github.com/j4velin/Pedometer) | A lightweight pedometer app that uses the hardware step-sensor. | `Java` | `Apache-2.0` | 1.4k | — |
 | [**RunnerUp**](https://github.com/jonasoreland/runnerup) | An open-source run tracker for tracking fitness activities. | `Java` | `GPL-3.0` | 940 | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=org.runnerup) |
+| [**SoulSync**](https://github.com/Antimatter543/mood-tracker) | A free mood tracker that stores everything on-device in SQLite, with no account, ads, or subscription. | `TypeScript` | `GPL-3.0` | 1 | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=com.raeduslabs.soulsyncapp) |
 | [**trale**](https://github.com/QuantumPhysique/trale) | A simple and privacy-respecting body weight diary app built with Flutter. | `Dart` | `AGPL-3.0` | 183 | — |
 
 ---


### PR DESCRIPTION
Adds SoulSync to categories/health_fitness.md, in alphabetical position.

SoulSync is a free, open-source mood tracker for Android. Everything is stored 100% on-device in SQLite, no account, no cloud sync, no ads, no subscription, with full data export.

- Repo: https://github.com/Antimatter543/mood-tracker
- License: GPL-3.0

Disclosure: we maintain this app (built by our founder).