### PR TITLE
Add Chompass to Health & Fitness

### DIFF
--- a/categories/health_fitness.md
+++ b/categories/health_fitness.md
@@ -9,6 +9,7 @@ A curated list of open-source health, wellness, and fitness apps for Android. Th
 | [**Aarogya Setu**](https://github.com/nic-delhi/AarogyaSetu_Android) | A contact tracing and self-assessment app from the Government of India. | `Java` | `Apache-2.0` | 2.9k | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=nic.goi.aarogyasetu) |
 | [**Android app to collect medical data**](https://github.com/Ana06/medical-data-android) | An app designed to collect data for medical analysis. | `Java` | `GPL-3.0` | 28 | — |
 | [**Android heart rate monitor**](https://github.com/phishman3579/android-heart-rate-monitor) | Uses the phone's camera and flash to determine heart rate. | `Java` | `Apache-2.0` | 474 | — |
+| [**Chompass**](https://codeberg.org/fitguy/Chompass) | Ad-free calorie and food diary with optional BYOK / on-device AI; data stays on-device; open JSON export. | `Kotlin` | `MIT` | 1 | — |
 | [**fitPlant**](https://github.com/KrisKodira/fitPlant) | A fitness app where you grow virtual plants by tracking your exercise. | `Dart` | `MIT` | 32 | — |
 | [**Ishihara**](https://github.com/landtanin/Ishihara) | An application for testing color blindness using Ishihara plates. | `Java` | `MIT` | 3 | — |
 | [**OpenHearing**](https://github.com/HMAKT99/OpenHearing) | Checks your hearing, builds a personal per-ear sound profile, and amplifies quiet sound in real time on any earbuds. | `Kotlin` | `GPL-3.0` | 12 | — |


### PR DESCRIPTION
disclosure: im the maintainer :)

Add Chompass to Health & Fitness (alphabetically between "Android heart rate monitor" and fitPlant).

Chompass is an ad-free calorie and food diary for Android (companion browser PWA). Maintained fork of Fud AI with a different application ID: no ads, no analytics SDKs, no account. Diary and body-metrics stay on-device; exports are open JSON. Optional AI is BYOK or optional on-device Gemma 4, neither required for normal logging.

licence: MIT
Source: https://codeberg.org/fitguy/Chompass
distribution: Obtainium / Codeberg Releases for now; F-Droid in progress (package app.chompass), will update when completed :)
website: https://chompass.app
PWA: https://chompass.app/app