### PR TITLE
Add Expanda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://github.com/pcqpcq/open-source-android-apps/stargazers"><img src="https://img.shields.io/github/stars/pcqpcq/open-source-android-apps?style=for-the-badge&color=gold" alt="GitHub stars"></a>
   <a href="https://github.com/pcqpcq/open-source-android-apps/network/members"><img src="https://img.shields.io/github/forks/pcqpcq/open-source-android-apps?style=for-the-badge&color=blue" alt="GitHub forks"></a>
-  <a href="https://github.com/pcqpcq/open-source-android-apps#%EF%B8%8F-categories"><img src="https://img.shields.io/badge/Total%20Apps-496-brightgreen?style=for-the-badge" alt="Total Apps"></a>
+  <a href="https://github.com/pcqpcq/open-source-android-apps#%EF%B8%8F-categories"><img src="https://img.shields.io/badge/Total%20Apps-497-brightgreen?style=for-the-badge" alt="Total Apps"></a>
   <a href="https://github.com/pcqpcq/open-source-android-apps/commits/master"><img src="https://img.shields.io/github/last-commit/pcqpcq/open-source-android-apps?style=for-the-badge" alt="GitHub last commit"></a>
   <a href="https://github.com/pcqpcq/open-source-android-apps/blob/master/LICENSE"><img src="https://img.shields.io/github/license/pcqpcq/open-source-android-apps?style=for-the-badge" alt="License"></a>
 </p>
@@ -65,7 +65,7 @@
 | [🎬 Multi-Media](categories/multi_media.md) | Video players, music apps, and editors. | 51 |
 | [📰 News & Magazines](categories/news_and_magazines.md) | RSS readers and news aggregators. | 40 |
 | [🎨 Personalization](categories/personalization.md) | Launchers, wallpapers, and UI tweaks. | 18 |
-| [📈 Productivity](categories/productivity.md) | Note-taking, task management, and office tools. | 48 |
+| [📈 Productivity](categories/productivity.md) | Note-taking, task management, and office tools. | 49 |
 | [🌐 Social Network](categories/social_network.md) | Clients for popular social platforms. | 51 |
 | [🛠️ Tools](categories/tools.md) | Utilities, system tools, and keyboards. | 122 |
 | [🗺️ Travel & Local](categories/travel_and_local.md) | Maps, navigation, and travel guides. | 18 |

--- a/categories/productivity.md
+++ b/categories/productivity.md
@@ -16,6 +16,7 @@ A curated list of open-source tools for note-taking, file management, task track
 | [**DeviceAnalyzer**](https://github.com/blurr-world/DeviceAnalyzer) | Provides detailed insights into your device's hardware specifications. | `Java` | `MIT` | 8 | — |
 | [**EarthViewer**](https://github.com/PDDStudio/earthview-android) | A wallpaper application and showcase for the `earthview-android` library. | `Java` | `Apache-2.0` | 135 | — |
 | [**EverMemo**](https://github.com/daimajia/EverMemo) | A fast and simple memo app for recording, organizing, and sharing notes. | `Java` | `MIT` | 797 | — |
+| [**Expanda**](https://github.com/diegomarzaa/expanda) | Offline text expansion with reusable snippets and dynamic templates, without Internet permission. | `Kotlin` | `MIT` | 0 | [GitHub Releases](https://github.com/diegomarzaa/expanda/releases) |
 | [**Habitica**](https://github.com/HabitRPG/habitica-android) | A habit tracker that gamifies your goals, treating them like an RPG. | `Kotlin` | `GPL-3.0` | 1.8k | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=com.habitrpg.android.habitica) |
 | [**Habito**](https://github.com/ivan-magda/Habito) | A simple habit tracker that uses Firebase Realtime Database. (Archived) | `Kotlin` | `MIT` | 80 | — |
 | [**InstaChat**](https://github.com/mohak1712/Insta-Chat) | A chat-head style app that lets you read and reply to messages from any screen. | `Java` | Not specified | 118 | — |


### PR DESCRIPTION
Adds [Expanda](https://github.com/diegomarzaa/expanda) to the Productivity category.\n\nExpanda is an MIT-licensed Android text expander written in Kotlin. It works offline, provides reusable snippets and dynamic templates, and does not request Internet permission. A signed APK is available through GitHub Releases.\n\nValidated with `python scripts/check_repo.py`.