### PR TITLE
Add Herold to Wearable Apps

### DIFF
--- a/categories/android_wear.md
+++ b/categories/android_wear.md
@@ -11,7 +11,7 @@ A curated list of open-source applications, watch faces, and operating systems f
 | [**AsteroidOS Sync**](https://github.com/AsteroidOS/AsteroidOSSync) | The official sync client to connect your phone to an AsteroidOS watch. | `Java` | `GPL-3.0` | 114 | [![F-Droid](https://f-droid.org/badge/get-it-on.svg)](https://f-droid.org/packages/org.asteroidos.sync) |
 | [**Binary Watch Face**](https://github.com/dwa012/WearBinaryWatchFace) | A watch face that displays the time in binary format. | `Java` | `Apache-2.0` | 57 | — |
 | [**FORM Watch Face**](https://github.com/romannurik/FORMWatchFace) | A unique watch face based on the FORM event typeface. | `Java` | `Apache-2.0` | 254 | — |
-| [**Herold**](https://github.com/chackrahunter/herold) | Runs a Samsung Galaxy Watch from an iPhone with no Google account: ANCS notifications, health sensor readouts, an account-free app store and a watch face. | `Java` | `MIT` | 0 | [Releases](https://github.com/chackrahunter/herold/releases/latest) |
+| [**Herold**](https://github.com/chackrahunter/herold) | Runs a Samsung Galaxy Watch from an iPhone with no Google account: ANCS notifications, health sensor readouts, an account-free app store and a watch face. | `Java` | `MIT` | 0 | — |
 | [**LapseFace**](https://github.com/matteolobello/lapseface) | A watch face that allows you to create time-lapses. (Archived) | `Java` | `Apache-2.0` | 7 | — |
 | [**LCARS Watchface**](https://github.com/llelectronics/lcars-v1-watchface-asteroidos) | A Star Trek LCARS-themed watch face specifically for AsteroidOS. | `QML` | `GPL-3.0` | 3 | — |
 | [**Tip Calculator**](https://github.com/mbcrump/FirstGoogleWearableApp) | A simple, voice-activated tip calculator for Wear OS. | `Java` | Not specified | 11 | — |

--- a/categories/android_wear.md
+++ b/categories/android_wear.md
@@ -11,6 +11,7 @@ A curated list of open-source applications, watch faces, and operating systems f
 | [**AsteroidOS Sync**](https://github.com/AsteroidOS/AsteroidOSSync) | The official sync client to connect your phone to an AsteroidOS watch. | `Java` | `GPL-3.0` | 114 | [![F-Droid](https://f-droid.org/badge/get-it-on.svg)](https://f-droid.org/packages/org.asteroidos.sync) |
 | [**Binary Watch Face**](https://github.com/dwa012/WearBinaryWatchFace) | A watch face that displays the time in binary format. | `Java` | `Apache-2.0` | 57 | — |
 | [**FORM Watch Face**](https://github.com/romannurik/FORMWatchFace) | A unique watch face based on the FORM event typeface. | `Java` | `Apache-2.0` | 254 | — |
+| [**Herold**](https://github.com/chackrahunter/herold) | Runs a Samsung Galaxy Watch from an iPhone with no Google account: ANCS notifications, health sensor readouts, an account-free app store and a watch face. | `Java` | `MIT` | 0 | [Releases](https://github.com/chackrahunter/herold/releases/latest) |
 | [**LapseFace**](https://github.com/matteolobello/lapseface) | A watch face that allows you to create time-lapses. (Archived) | `Java` | `Apache-2.0` | 7 | — |
 | [**LCARS Watchface**](https://github.com/llelectronics/lcars-v1-watchface-asteroidos) | A Star Trek LCARS-themed watch face specifically for AsteroidOS. | `QML` | `GPL-3.0` | 3 | — |
 | [**Tip Calculator**](https://github.com/mbcrump/FirstGoogleWearableApp) | A simple, voice-activated tip calculator for Wear OS. | `Java` | Not specified | 11 | — |


### PR DESCRIPTION
Adds one entry to `categories/android_wear.md`, alphabetically between **FORM Watch Face** and **LapseFace**.

**[Herold](https://github.com/chackrahunter/herold)** runs a Samsung Galaxy Watch from an iPhone with no Google account — the combination Samsung does not support. It covers iPhone notifications over ANCS, the health sensors (ECG, heart rate, SpO2, skin temperature), an account-free app store, and a watch face. Everything builds without Gradle, straight from the Android SDK command line tools.

Checked against the rules:

- **Open-source** — MIT, public repository, `Java`, all confirmed from the GitHub API.
- **One entry, one category** — the three apps live in one repository, so they get one row; the parts are named in the description.
- **Stars: 0** — accurate as of opening this. I left it honest rather than rounding it up; `maintenance.yml` will refresh it anyway.
- **Download** — a releases link, which `CONTRIBUTING.md` lists as an accepted form. Prebuilt APKs are attached to the latest release. Happy to change it to `—` if you would rather keep this file badge-free.

One thing worth stating up front: the app-store component links against `gplayapi`, which is GPL-3.0, so no prebuilt APK for that part is distributed — it is source-only, and the per-library licences are listed in [DRITTANBIETER.md](https://github.com/chackrahunter/herold/blob/master/DRITTANBIETER.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)