### PR TITLE
Add TrimPlayer under Multi-Media

### DIFF
--- a/categories/multi_media.md
+++ b/categories/multi_media.md
@@ -53,6 +53,7 @@ A curated list of open-source players, galleries, clients, and other multi-media
 | [**Telecine**](https://github.com/JakeWharton/Telecine) | A simple app for recording full-resolution video of your device's screen. | `Java` | `Apache-2.0` | 2.4k | — |
 | [**Timber**](https://github.com/naman14/Timber) | A beautiful, fully-featured Material Design music player. | `Java` | `GPL-3.0` | 7.0k | — |
 | [**Track My Shows**](https://github.com/chashmeetsingh/TrackMyShows) | A simple app for tracking your favorite TV shows. (Archived) | `Java` | `GPL-3.0` | 11 | — |
+| [**TrimPlayer**](https://github.com/yonatanholdings/TrimPlayer) | A podcast player that automatically skips intros, ads and outros by detecting audio that repeats across a show's episodes. | `Java` | `GPL-3.0` | 0 | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=com.trimplayer) |
 | [**Twire**](https://github.com/Perflyst/Twire) | An open-source, ad-free Twitch browser and stream player for Android. | `Java` | `GPL-3.0` | 5 | [![F-Droid](https://f-droid.org/badge/get-it-on.svg)](https://f-droid.org/packages/com.perflyst.twire) |
 | [**UniversalMusicPlayer**](https://github.com/android/uamp) | A Google sample demonstrating a cross-platform audio media app. | `Kotlin` | `Apache-2.0` | 13.2k | — |
 | [**Vanilla Music**](https://github.com/vanilla-music/vanilla) | A clean, simple, and free open-source music player. | `Java` | `GPL-3.0` | 1.3k | — |


### PR DESCRIPTION
Adds **TrimPlayer**, an open-source (GPL-3.0) Android podcast player.

It is an [AntennaPod](https://github.com/AntennaPod/AntennaPod) fork whose distinguishing feature is automatic intro/ad/outro skipping — it fingerprints audio that repeats across a show's episodes, rather than relying on manual chapter tags or a crowd-sourced database.

- Source: https://github.com/yonatanholdings/TrimPlayer
- Google Play: https://play.google.com/store/apps/details?id=com.trimplayer
- License: GPL-3.0 · Language: Java

Row inserted in alphabetical position between **Track My Shows** and **Twire** in `categories/multi_media.md`, following the 6-column format in CONTRIBUTING.

Per CONTRIBUTING ("Keeping Data Fresh"), I left the README category count and the Total Apps badge to the scheduled maintenance action rather than editing them by hand — `scripts/check_repo.py` therefore reports the expected +1 drift on `multi_media.md` and the total, and no other findings.

Disclosure: the entry was prepared with AI assistance; the facts above (license, fork lineage, mechanism, links) were each verified against the source repo and the live listing.