### PR TITLE
Add OpenPost to Business apps

### DIFF
--- a/categories/business.md
+++ b/categories/business.md
@@ -7,6 +7,7 @@ A curated list of open-source applications for e-commerce, ERP, CRM, and other b
 | App Name | Description | Language | License | ⭐ Stars | Download |
 | :--- | :--- | :---: | :---: | :---: | :---: |
 | [**OpenPetra**](https://github.com/openpetra/openpetra) | Administration software (CRM/ERP) for charitable organizations. | `C#` | `GPL-3.0` | 116 | — |
+| [**OpenPost**](https://github.com/getopenpost/openpost) | Native app for drafting, scheduling, and tracking social posts through OpenPost Hosted or a self-hosted server. | `TypeScript` | `AGPL-3.0` | 145 | [![Download](https://img.shields.io/badge/Download-Releases-blue)](https://github.com/getopenpost/openpost/releases/latest) |
 | [**Nextcloud**](https://github.com/nextcloud/android) | The official Android client for Nextcloud — access, share and sync files, calendars and contacts on your own server. | `Kotlin` | `GPL-2.0` | 5.6k | [![Google Play](https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg)](https://play.google.com/store/apps/details?id=com.nextcloud.client) |
 | [**OpenShop.io**](https://github.com/openshopio/openshop.io-android) | A mobile E-commerce solution connected to Facebook Ads and Google. (Archived) | `Java` | `MIT` | 503 | — |
 


### PR DESCRIPTION
Add the native OpenPost Android app to Business. It is open source under AGPL-3.0 and ships a signed APK with each GitHub release. The row states that the app needs OpenPost Hosted or a self-hosted server.

I maintain OpenPost. I checked the repository, latest release, license, and package details before submitting. `git diff --check` passes.